### PR TITLE
daab init を実行可能にした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ kotlinVersion.properties
 
 ### for local development
 install-local.gradle
-local-dev/
+local-dev/*

--- a/plugin/src/main/kotlin/com/lisb/daab/Configurations.kt
+++ b/plugin/src/main/kotlin/com/lisb/daab/Configurations.kt
@@ -71,11 +71,11 @@ object Configurations {
                 it.outputs.upToDateWhen { project.file(daab.daabAppDir).exists() }
             }
 
-    fun configureDaabInitTask(project: Project, daab: Daab): Task = project.tasks.create<Exec>(Daab.daabInit)
+    fun configureDaabInitTask(project: Project, daab: Daab): Task = project.tasks.create<DaabTask>(Daab.daabInit)
             .also { it.description = "init daab project directory" }
             .also { it.group = Daab.group }
             .also { it.dependsOn(Daab.prepareDaabDirectory) }
-            .also { it.executable = daab.executable }
+            .also { it.daab = daab }
             .also { it.args("init") }
             .also { it.environment("PATH", appendPath(project.file(daab.executable))) }
             .also { it.workingDir(daab.daabAppDir) }

--- a/plugin/src/main/kotlin/com/lisb/daab/DaabTask.kt
+++ b/plugin/src/main/kotlin/com/lisb/daab/DaabTask.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lisb.daab
+
+import org.gradle.api.tasks.Exec
+
+
+open class DaabTask: Exec() {
+
+    lateinit var daab: Daab
+
+    override fun exec() {
+        this.executable = daab.executable
+        super.exec()
+    }
+}

--- a/plugin/src/main/kotlin/com/lisb/daab/Tasks.kt
+++ b/plugin/src/main/kotlin/com/lisb/daab/Tasks.kt
@@ -70,9 +70,7 @@ open class WritePackageJson: DefaultTask() {
     "kotlin": "^${project.properties["kotlinVersion"]}",
 """
             else
-                "\n".also { 
-                    println("${project.properties["kotlinVersion"]}")
-                }
+                "\n"
 
     @TaskAction
     open fun appendJsonFile(): Unit = StringBuilder()


### PR DESCRIPTION
実行時に `Exec`  にダイナミックに `executable` を設定できないので、 `Exec` を継承した `DaabTask` を作って、lazy に設定可能にした